### PR TITLE
Update Get-WUGDevices.ps1

### DIFF
--- a/functions/Get-WUGDevices.ps1
+++ b/functions/Get-WUGDevices.ps1
@@ -53,9 +53,7 @@ function Get-WUGDevices {
     if ($SearchValue) {
         $uri += "&search=${SearchValue}"
     }
-    else {
-        $SearchValue = Read-Host "Enter the search value either IP, hostname, or display name."
-    }
+    
     $currentPage = 1
     $allDevices = @()
     do {


### PR DESCRIPTION
removed 
else {
        $SearchValue = Read-Host "Enter the search value either IP, hostname, or display name."
    }

because with that in there, it makes the $SearchValue mandatory.  You have to put something there.  Without it, it can still be added as an optional attribute to the Get-WUGDevices.  Now you can just select a group and go with it, or select a group and do a search ...

### Requirements

* This template is required. Any request that does not include enough information may be closed at the maintainers' discretion.
* Have you (put an X between the brackets on each line to confirm):
    * [ ] Written new test cases to ensure no regression bugs occur?
    * [ ] Ensured all test cases are now passing?
    * [ ] Ensured that PowerShell Script Analyser issues and warnings are completely resolved?
    * [ ] Updated any help or documentation that may be impacted by your changes?

### Description of the Change

[ We must be able to understand the design of your change from this description. If we cannot get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. ]

### Testing

[ Please describe the testing you have performed ]

### Associated/Resolved Issues

[ Enter any applicable issues here ]

> Note: By creating a pull request, you are expected to comply with this project's Code of Conduct.

<!--

    This template is based upon the work by the Atom project, https://github.com/atom/atom/

-->